### PR TITLE
Fix uninitialized

### DIFF
--- a/android/src/main/kotlin/ir/cafebazaar/flutter_poolakey/FlutterPoolakeyPlugin.kt
+++ b/android/src/main/kotlin/ir/cafebazaar/flutter_poolakey/FlutterPoolakeyPlugin.kt
@@ -280,7 +280,9 @@ class FlutterPoolakeyPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         activityBinding = null
         purchaseCallback = null
         channel.setMethodCallHandler(null)
-        paymentConnection.disconnect()
+        if(::paymentConnection.isInitialized){
+            paymentConnection.disconnect()
+        }
     }
 
     override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {


### PR DESCRIPTION
Hi, I've fix issues.

`E/AndroidRuntime(15407): java.lang.RuntimeException: Unable to destroy activity {com.x/com.x.MainActivity}: kotlin.UninitializedPropertyAccessException: lateinit property paymentConnection has not been initialized
E/AndroidRuntime(15407): 	at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:5686)
E/AndroidRuntime(15407): 	at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:5731)
E/AndroidRuntime(15407): 	at android.app.servertransaction.DestroyActivityItem.execute(DestroyActivityItem.java:44)
E/AndroidRuntime(15407): 	at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
E/AndroidRuntime(15407): 	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
E/AndroidRuntime(15407): 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2336)
E/AndroidRuntime(15407): 	at android.os.Handler.dispatchMessage(Handler.java:106)
E/AndroidRuntime(15407): 	at android.os.Looper.loop(Looper.java:246)
E/AndroidRuntime(15407): 	at android.app.ActivityThread.main(ActivityThread.java:8653)
E/AndroidRuntime(15407): 	at java.lang.reflect.Method.invoke(Native Method)
E/AndroidRuntime(15407): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:602)
E/AndroidRuntime(15407): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1130)
E/AndroidRuntime(15407): Caused by: kotlin.UninitializedPropertyAccessException: lateinit property paymentConnection has not been initialized
E/AndroidRuntime(15407): 	at ir.cafebazaar.flutter_poolakey.FlutterPoolakeyPlugin.onDetachedFromActivity(FlutterPoolakeyPlugin.kt:283)
E/AndroidRuntime(15407): 	at io.flutter.embedding.engine.FlutterEngineConnectionRegistry.detachFromActivity(FlutterEngineConnectionRegistry.java:383)
E/AndroidRuntime(15407): 	at io.flutter.embedding.android.FlutterActivityAndFragmentDelegate.onDetach(FlutterActivityAndFragmentDelegate.java:681)
E/AndroidRuntime(15407): 	at io.flutter.embedding.android.FlutterFragment.onDetach(FlutterFragment.java:878)
E/AndroidRuntime(15407): 	at androidx.fragment.app.Fragment.performDetach(Fragment.java:3261)
E/AndroidRuntime(15407): 	at androidx.fragment.app.FragmentStateManager.detach(FragmentStateManager.java:818)
E/AndroidRuntime(15407): 	at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:338)
E/AndroidRuntime(15407): 	at androidx.fragment.app.SpecialEffectsController$FragmentStateManagerOperation.complete(SpecialEffectsController.java:771)
E/AndroidRuntime(15407): 	at androidx.fragment.app.SpecialEffectsController$Operation.cancel(SpecialEffectsController.java:615)
E/AndroidRuntime(15407): 	at androidx.fragment.app.SpecialEffectsController.forceCompleteAllOperations(SpecialEffectsController.java:350)
E/AndroidRuntime(15407): 	at androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:2844)
E/AndroidRuntime(15407): 	at androidx.fragment.app.FragmentManager.dispatchDestroy(FragmentManager.java:2820)
E/AndroidRuntime(15407): 	at androidx.fragment.app.FragmentController.dispatchDestroy(FragmentController.java:345)
E/AndroidRuntime(15407): 	at androidx.fragment.app.FragmentActivity.onDestroy(FragmentActivity.java:306)
E/AndroidRuntime(15407): 	at android.app.Activity.performDestroy(Activity.java:8468)
E/AndroidRuntime(15407): 	at android.app.Instrumentation.callActivityOnDestroy(Instrumentation.java:1344)
E/AndroidRuntime(15407): 	at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:5671)
E/AndroidRuntime(15407): 	... 11 more`