### PR TITLE
Fix build.gradle to support AGP 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,6 +38,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'ir.cafebazaar.flutter_poolakey'
     compileSdkVersion 33
 
     compileOptions {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,6 +45,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    buildFeatures {
+        buildConfig true
+    }
+
     kotlinOptions {
         jvmTarget = '1.8'
     }


### PR DESCRIPTION
Hi
This PR fixes these errors in the build with AGP 8:
```
1: Task failed with an exception.
-----------
* What went wrong:
A problem occurred configuring project ':flutter_poolakey'.
> com.android.builder.errors.EvalIssueException: Build Type 'debug' contains custom BuildConfig fields, but the feature is disabled.
  To enable the feature, add the following to your module-level build.gradle:
  `android.buildFeatures.buildConfig true`
==============================================================================

2: Task failed with an exception.
-----------
* What went wrong:
Failed to query the value of property 'buildFlowServiceProperty'.
> Could not isolate value org.jetbrains.kotlin.gradle.plugin.statistics.BuildFlowService$Parameters_Decorated@38261142 of type BuildFlowService.Parameters
   > A problem occurred configuring project ':flutter_poolakey'.
      > com.android.builder.errors.EvalIssueException: Build Type 'debug' contains custom BuildConfig fields, but the feature is disabled.
        To enable the feature, add the following to your module-level build.gradle:
        `android.buildFeatures.buildConfig true`
```
```
1: Task failed with an exception.
-----------
* What went wrong:
A problem occurred configuring project ':flutter_poolakey'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistan
t/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.
==============================================================================

2: Task failed with an exception.
-----------
* What went wrong:
Failed to query the value of property 'buildFlowServiceProperty'.
> Could not isolate value org.jetbrains.kotlin.gradle.plugin.statistics.BuildFlowService$Parameters_Decorated@72a0f588 of type BuildFlowService.Parameters
   > A problem occurred configuring project ':flutter_poolakey'.
      > Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
         > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

           If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-as
sistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.
```