### PR TITLE
Fix illegal state exception on connect

### DIFF
--- a/android/src/main/kotlin/ir/cafebazaar/flutter_poolakey/FlutterPoolakeyPlugin.kt
+++ b/android/src/main/kotlin/ir/cafebazaar/flutter_poolakey/FlutterPoolakeyPlugin.kt
@@ -37,7 +37,7 @@ class FlutterPoolakeyPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
         activityBinding = binding
         channel =
-            MethodChannel(flutterPluginBinding.binaryMessenger, "ir.cafebazaar.flutter_poolakey")
+                MethodChannel(flutterPluginBinding.binaryMessenger, "ir.cafebazaar.flutter_poolakey")
         channel.setMethodCallHandler(this)
     }
 
@@ -46,54 +46,65 @@ class FlutterPoolakeyPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             "version" -> {
                 getVersion(result);
             }
+
             "connect" -> {
                 val inAppBillingKey = call.argument<String>("in_app_billing_key")
                 connect(inAppBillingKey, result)
-            } 
+            }
+
             "disconnect" -> {
                 disconnect(result)
             }
+
             "purchase" -> {
                 startActivity(
-                    activity = requireActivity,
-                    command = PaymentActivity.Command.Purchase,
-                    productId = call.argument<String>("product_id")!!,
-                    result = result,
-                    payload = call.argument<String>("payload"),
-                    dynamicPriceToken = call.argument<String>("dynamicPriceToken"),
+                        activity = requireActivity,
+                        command = PaymentActivity.Command.Purchase,
+                        productId = call.argument<String>("product_id")!!,
+                        result = result,
+                        payload = call.argument<String>("payload"),
+                        dynamicPriceToken = call.argument<String>("dynamicPriceToken"),
                 )
             }
+
             "subscribe" -> {
                 startActivity(
-                    activity = requireActivity,
-                    command = PaymentActivity.Command.Subscribe,
-                    productId = call.argument<String>("product_id")!!,
-                    result = result,
-                    payload = call.argument<String>("payload"),
-                    dynamicPriceToken = call.argument<String>("dynamicPriceToken"),
+                        activity = requireActivity,
+                        command = PaymentActivity.Command.Subscribe,
+                        productId = call.argument<String>("product_id")!!,
+                        result = result,
+                        payload = call.argument<String>("payload"),
+                        dynamicPriceToken = call.argument<String>("dynamicPriceToken"),
                 )
             }
+
             "consume" -> {
                 val purchaseToken = call.argument<String>("purchase_token")!!
                 consume(purchaseToken, result)
             }
+
             "get_all_purchased_products" -> {
                 getAllPurchasedProducts(result)
             }
+
             "get_all_subscribed_products" -> {
                 getAllSubscribedProducts(result)
             }
+
             "get_in_app_sku_details" -> {
                 val skuIds = call.argument<List<String>>("sku_ids")!!
                 getInAppSkuDetails(skuIds, result)
             }
+
             "get_subscription_sku_details" -> {
                 val skuIds = call.argument<List<String>>("sku_ids")!!
                 getSubscriptionSkuDetails(skuIds, result)
             }
+
             "checkTrialSubscription" -> {
                 checkTrialSubscription(result)
             }
+
             else -> result.notImplemented()
         }
     }
@@ -114,10 +125,10 @@ class FlutterPoolakeyPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
         paymentConnection = payment.connect {
             connectionSucceed {
-                result.success(true)
+                channel.invokeMethod("connectSuccess", null)
             }
             connectionFailed {
-                result.error("CONNECTION_HAS_FAILED", it.toString(), null)
+                channel.invokeMethod("connectFailed", null)
             }
             disconnected {
                 channel.invokeMethod("disconnected", null)
@@ -125,20 +136,20 @@ class FlutterPoolakeyPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         }
     }
 
-    private fun disconnect(result: Result){
+    private fun disconnect(result: Result) {
         paymentConnection.disconnect()
         result.success(null)
     }
 
     fun startActivity(
-        activity: Activity,
-        command: PaymentActivity.Command,
-        productId: String,
-        result: Result,
-        payload: String
-        ?,
-        dynamicPriceToken: String
-        ?
+            activity: Activity,
+            command: PaymentActivity.Command,
+            productId: String,
+            result: Result,
+            payload: String
+            ?,
+            dynamicPriceToken: String
+            ?
     ) {
         if (paymentConnection.getState() != ConnectionState.Connected) {
             result.error("PURCHASE_FAILED", "In order to purchasing, connect to Poolakey!", null)
@@ -146,22 +157,22 @@ class FlutterPoolakeyPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         }
 
         PaymentActivity.start(
-            activity,
-            command,
-            productId,
-            payment,
-            result,
-            payload,
-            dynamicPriceToken
+                activity,
+                command,
+                productId,
+                payment,
+                result,
+                payload,
+                dynamicPriceToken
         )
     }
 
     private fun consume(purchaseToken: String, result: Result) {
         if (paymentConnection.getState() != ConnectionState.Connected) {
             result.error(
-                "PAYMENT_CONNECTION_IS_NOT_CONNECTED",
-                "PaymentConnection is not connected (state: ${paymentConnection.getState()})",
-                null
+                    "PAYMENT_CONNECTION_IS_NOT_CONNECTED",
+                    "PaymentConnection is not connected (state: ${paymentConnection.getState()})",
+                    null
             )
             return
         }
@@ -178,17 +189,17 @@ class FlutterPoolakeyPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private fun checkTrialSubscription(result: Result) {
         if (paymentConnection.getState() != ConnectionState.Connected) {
             result.error(
-                "PAYMENT_CONNECTION_IS_NOT_CONNECTED",
-                "PaymentConnection is not connected (state: ${paymentConnection.getState()})",
-                null
+                    "PAYMENT_CONNECTION_IS_NOT_CONNECTED",
+                    "PaymentConnection is not connected (state: ${paymentConnection.getState()})",
+                    null
             )
             return
         }
         payment.checkTrialSubscription {
             checkTrialSubscriptionSucceed { trialSubscriptionInfo ->
                 result.success(hashMapOf(
-                    "isAvailable" to trialSubscriptionInfo.isAvailable,
-                    "trialPeriodDays" to trialSubscriptionInfo.trialPeriodDays))
+                        "isAvailable" to trialSubscriptionInfo.isAvailable,
+                        "trialPeriodDays" to trialSubscriptionInfo.trialPeriodDays))
             }
 
             checkTrialSubscriptionFailed {
@@ -201,9 +212,9 @@ class FlutterPoolakeyPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private fun getAllPurchasedProducts(result: Result) {
         if (paymentConnection.getState() != ConnectionState.Connected) {
             result.error(
-                "PAYMENT_CONNECTION_IS_NOT_CONNECTED",
-                "PaymentConnection is not connected (state: ${paymentConnection.getState()})",
-                null
+                    "PAYMENT_CONNECTION_IS_NOT_CONNECTED",
+                    "PaymentConnection is not connected (state: ${paymentConnection.getState()})",
+                    null
             )
             return
         }
@@ -220,9 +231,9 @@ class FlutterPoolakeyPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private fun getAllSubscribedProducts(result: Result) {
         if (paymentConnection.getState() != ConnectionState.Connected) {
             result.error(
-                "PAYMENT_CONNECTION_IS_NOT_CONNECTED",
-                "PaymentConnection is not connected (state: ${paymentConnection.getState()})",
-                null
+                    "PAYMENT_CONNECTION_IS_NOT_CONNECTED",
+                    "PaymentConnection is not connected (state: ${paymentConnection.getState()})",
+                    null
             )
             return
         }
@@ -239,9 +250,9 @@ class FlutterPoolakeyPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private fun getInAppSkuDetails(skuIds: List<String>, result: Result) {
         if (paymentConnection.getState() != ConnectionState.Connected) {
             result.error(
-                "PAYMENT_CONNECTION_IS_NOT_CONNECTED",
-                "PaymentConnection is not connected (state: ${paymentConnection.getState()})",
-                null
+                    "PAYMENT_CONNECTION_IS_NOT_CONNECTED",
+                    "PaymentConnection is not connected (state: ${paymentConnection.getState()})",
+                    null
             )
             return
         }
@@ -259,9 +270,9 @@ class FlutterPoolakeyPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private fun getSubscriptionSkuDetails(skuIds: List<String>, result: Result) {
         if (paymentConnection.getState() != ConnectionState.Connected) {
             result.error(
-                "PAYMENT_CONNECTION_IS_NOT_CONNECTED",
-                "PaymentConnection is not connected (state: ${paymentConnection.getState()})",
-                null
+                    "PAYMENT_CONNECTION_IS_NOT_CONNECTED",
+                    "PaymentConnection is not connected (state: ${paymentConnection.getState()})",
+                    null
             )
             return
         }
@@ -288,7 +299,7 @@ class FlutterPoolakeyPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         activityBinding = null
         purchaseCallback = null
         channel.setMethodCallHandler(null)
-        if(::paymentConnection.isInitialized){
+        if (::paymentConnection.isInitialized) {
             paymentConnection.disconnect()
         }
     }

--- a/android/src/main/kotlin/ir/cafebazaar/flutter_poolakey/FlutterPoolakeyPlugin.kt
+++ b/android/src/main/kotlin/ir/cafebazaar/flutter_poolakey/FlutterPoolakeyPlugin.kt
@@ -37,7 +37,7 @@ class FlutterPoolakeyPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
         activityBinding = binding
         channel =
-                MethodChannel(flutterPluginBinding.binaryMessenger, "ir.cafebazaar.flutter_poolakey")
+            MethodChannel(flutterPluginBinding.binaryMessenger, "ir.cafebazaar.flutter_poolakey")
         channel.setMethodCallHandler(this)
     }
 
@@ -58,23 +58,23 @@ class FlutterPoolakeyPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
             "purchase" -> {
                 startActivity(
-                        activity = requireActivity,
-                        command = PaymentActivity.Command.Purchase,
-                        productId = call.argument<String>("product_id")!!,
-                        result = result,
-                        payload = call.argument<String>("payload"),
-                        dynamicPriceToken = call.argument<String>("dynamicPriceToken"),
+                    activity = requireActivity,
+                    command = PaymentActivity.Command.Purchase,
+                    productId = call.argument<String>("product_id")!!,
+                    result = result,
+                    payload = call.argument<String>("payload"),
+                    dynamicPriceToken = call.argument<String>("dynamicPriceToken"),
                 )
             }
 
             "subscribe" -> {
                 startActivity(
-                        activity = requireActivity,
-                        command = PaymentActivity.Command.Subscribe,
-                        productId = call.argument<String>("product_id")!!,
-                        result = result,
-                        payload = call.argument<String>("payload"),
-                        dynamicPriceToken = call.argument<String>("dynamicPriceToken"),
+                    activity = requireActivity,
+                    command = PaymentActivity.Command.Subscribe,
+                    productId = call.argument<String>("product_id")!!,
+                    result = result,
+                    payload = call.argument<String>("payload"),
+                    dynamicPriceToken = call.argument<String>("dynamicPriceToken"),
                 )
             }
 
@@ -125,10 +125,10 @@ class FlutterPoolakeyPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
         paymentConnection = payment.connect {
             connectionSucceed {
-                channel.invokeMethod("connectSuccess", null)
+                channel.invokeMethod("connectionSucceed", null)
             }
             connectionFailed {
-                channel.invokeMethod("connectFailed", null)
+                channel.invokeMethod("connectionFailed", it.toString(), null)
             }
             disconnected {
                 channel.invokeMethod("disconnected", null)
@@ -142,14 +142,14 @@ class FlutterPoolakeyPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     }
 
     fun startActivity(
-            activity: Activity,
-            command: PaymentActivity.Command,
-            productId: String,
-            result: Result,
-            payload: String
-            ?,
-            dynamicPriceToken: String
-            ?
+        activity: Activity,
+        command: PaymentActivity.Command,
+        productId: String,
+        result: Result,
+        payload: String
+        ?,
+        dynamicPriceToken: String
+        ?
     ) {
         if (paymentConnection.getState() != ConnectionState.Connected) {
             result.error("PURCHASE_FAILED", "In order to purchasing, connect to Poolakey!", null)
@@ -157,22 +157,22 @@ class FlutterPoolakeyPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         }
 
         PaymentActivity.start(
-                activity,
-                command,
-                productId,
-                payment,
-                result,
-                payload,
-                dynamicPriceToken
+            activity,
+            command,
+            productId,
+            payment,
+            result,
+            payload,
+            dynamicPriceToken
         )
     }
 
     private fun consume(purchaseToken: String, result: Result) {
         if (paymentConnection.getState() != ConnectionState.Connected) {
             result.error(
-                    "PAYMENT_CONNECTION_IS_NOT_CONNECTED",
-                    "PaymentConnection is not connected (state: ${paymentConnection.getState()})",
-                    null
+                "PAYMENT_CONNECTION_IS_NOT_CONNECTED",
+                "PaymentConnection is not connected (state: ${paymentConnection.getState()})",
+                null
             )
             return
         }
@@ -189,17 +189,20 @@ class FlutterPoolakeyPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private fun checkTrialSubscription(result: Result) {
         if (paymentConnection.getState() != ConnectionState.Connected) {
             result.error(
-                    "PAYMENT_CONNECTION_IS_NOT_CONNECTED",
-                    "PaymentConnection is not connected (state: ${paymentConnection.getState()})",
-                    null
+                "PAYMENT_CONNECTION_IS_NOT_CONNECTED",
+                "PaymentConnection is not connected (state: ${paymentConnection.getState()})",
+                null
             )
             return
         }
         payment.checkTrialSubscription {
             checkTrialSubscriptionSucceed { trialSubscriptionInfo ->
-                result.success(hashMapOf(
+                result.success(
+                    hashMapOf(
                         "isAvailable" to trialSubscriptionInfo.isAvailable,
-                        "trialPeriodDays" to trialSubscriptionInfo.trialPeriodDays))
+                        "trialPeriodDays" to trialSubscriptionInfo.trialPeriodDays
+                    )
+                )
             }
 
             checkTrialSubscriptionFailed {
@@ -212,9 +215,9 @@ class FlutterPoolakeyPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private fun getAllPurchasedProducts(result: Result) {
         if (paymentConnection.getState() != ConnectionState.Connected) {
             result.error(
-                    "PAYMENT_CONNECTION_IS_NOT_CONNECTED",
-                    "PaymentConnection is not connected (state: ${paymentConnection.getState()})",
-                    null
+                "PAYMENT_CONNECTION_IS_NOT_CONNECTED",
+                "PaymentConnection is not connected (state: ${paymentConnection.getState()})",
+                null
             )
             return
         }
@@ -231,9 +234,9 @@ class FlutterPoolakeyPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private fun getAllSubscribedProducts(result: Result) {
         if (paymentConnection.getState() != ConnectionState.Connected) {
             result.error(
-                    "PAYMENT_CONNECTION_IS_NOT_CONNECTED",
-                    "PaymentConnection is not connected (state: ${paymentConnection.getState()})",
-                    null
+                "PAYMENT_CONNECTION_IS_NOT_CONNECTED",
+                "PaymentConnection is not connected (state: ${paymentConnection.getState()})",
+                null
             )
             return
         }
@@ -250,9 +253,9 @@ class FlutterPoolakeyPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private fun getInAppSkuDetails(skuIds: List<String>, result: Result) {
         if (paymentConnection.getState() != ConnectionState.Connected) {
             result.error(
-                    "PAYMENT_CONNECTION_IS_NOT_CONNECTED",
-                    "PaymentConnection is not connected (state: ${paymentConnection.getState()})",
-                    null
+                "PAYMENT_CONNECTION_IS_NOT_CONNECTED",
+                "PaymentConnection is not connected (state: ${paymentConnection.getState()})",
+                null
             )
             return
         }
@@ -270,9 +273,9 @@ class FlutterPoolakeyPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private fun getSubscriptionSkuDetails(skuIds: List<String>, result: Result) {
         if (paymentConnection.getState() != ConnectionState.Connected) {
             result.error(
-                    "PAYMENT_CONNECTION_IS_NOT_CONNECTED",
-                    "PaymentConnection is not connected (state: ${paymentConnection.getState()})",
-                    null
+                "PAYMENT_CONNECTION_IS_NOT_CONNECTED",
+                "PaymentConnection is not connected (state: ${paymentConnection.getState()})",
+                null
             )
             return
         }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -66,8 +66,10 @@ class _MyHomePageState extends State<MyHomePage> {
     var rsaKey =
         "MIHNMA0GCSqGSIb3DQEBAQUAA4G7ADCBtwKBrwDbkRScfggn+JSs+DzcZK20ZbxKPKv060aekC4dxqapamlgf9PncC5/4sqhUU4SdeKE770H1s7dJhmV5QEnzLawJTgiTzD3RFcadl2H4dduro/KxVyAe5nNKE/Xg+uRalLU/Hw9Or44m2xDyWESWj8sqweaGDUnsoHWJFsyVwwIj15fx3cDX6kjObC0gYns1o79x+COWCqyIlDwE2Pf7Xum55FASKFH8lqlYpEzR38CAwEAAQ== ";
     try {
-      connected = await FlutterPoolakey.connect(
+      await FlutterPoolakey.connect(
         rsaKey,
+        onConnectSuccess: () => connected = true,
+        onConnectFailed: () => connected = false,
         onDisconnected: () => showSnackBar("Poolakey disconnected!"),
       );
     } on Exception catch (e) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -68,24 +68,30 @@ class _MyHomePageState extends State<MyHomePage> {
     try {
       await FlutterPoolakey.connect(
         rsaKey,
-        onConnectSuccess: () => connected = true,
-        onConnectFailed: () => connected = false,
-        onDisconnected: () => showSnackBar("Poolakey disconnected!"),
+        onSucceed: () {
+          connected = true;
+          _updateState("Service: Connected");
+        },
+        onFailed: () {
+          connected = false;
+          _updateState("Service: Not Connected");
+        },
+        onDisconnected: () {
+          connected = false;
+          _updateState("Service: Not Connected");
+        },
       );
     } on Exception catch (e) {
       showSnackBar(e.toString());
-      setState(() {
-        status = "Service: Failed to Connect";
-      });
+      _updateState("Service: Failed to Connect");
     }
+  }
 
+  void _updateState(String message) {
     setState(() {
-      if (!connected) {
-        status = "Service: Not Connected";
-      } else {
-        status = "Service: Connected";
-      }
+      status = message;
     });
+    showSnackBar(message);
   }
 
   @override

--- a/lib/flutter_poolakey.dart
+++ b/lib/flutter_poolakey.dart
@@ -27,26 +27,26 @@ class FlutterPoolakey {
   /// You can also disable the local security check (only if you are using Bazaar's REST API)
   /// by passing null as [inAppBillingKey].
   ///
-  /// You should listen to [onConnectSuccess] callback to make sure FlutterPoolakey is connected successfully.
+  /// You should listen to [onSucceed] callback to make sure FlutterPoolakey is connected successfully.
   ///
-  /// You should listen to [onConnectFailed] callback to handle connect error.
+  /// You should listen to [onFailed] callback to handle connect error.
   ///
   /// You should listen to [onDisconnected] callback and call [FlutterPoolakey.connect] to reconnect again.
   ///
   /// This function may return an error, you should handle the error and check the stacktrace to resolve it.
   static Future<void> connect(String? inAppBillingKey,
-      {VoidCallback? onConnectSuccess,
-      VoidCallback? onConnectFailed,
+      {VoidCallback? onSucceed,
+      VoidCallback? onFailed,
       VoidCallback? onDisconnected}) async {
-    _registerConnectCallBack(onConnectSuccess, onConnectFailed, onDisconnected);
+    _registerConnectCallBack(onSucceed, onFailed, onDisconnected);
     await _channel
         .invokeMethod('connect', {'in_app_billing_key': inAppBillingKey});
   }
 
-  static void _registerConnectCallBack(VoidCallback? onConnectSuccess,
-      VoidCallback? onConnectFailed, VoidCallback? onDisconnected) {
-    if (onConnectSuccess == null &&
-        onConnectFailed == null &&
+  static void _registerConnectCallBack(VoidCallback? onConnectionSucceed,
+      VoidCallback? onConnectionFailed, VoidCallback? onDisconnected) {
+    if (onConnectionSucceed == null &&
+        onConnectionFailed == null &&
         onDisconnected == null) {
       return;
     }
@@ -54,11 +54,11 @@ class FlutterPoolakey {
       if (call.method == 'disconnected') {
         onDisconnected?.call();
         return Future.value(true);
-      } else if (call.method == 'connectSuccess') {
-        onConnectSuccess?.call();
+      } else if (call.method == 'connectionSucceed') {
+        onConnectionSucceed?.call();
         return Future.value(true);
-      } else if (call.method == 'connectFailed') {
-        onConnectFailed?.call();
+      } else if (call.method == 'connectionFailed') {
+        onConnectionFailed?.call();
         return Future.value(true);
       }
       throw StateError('method ${call.method} is not supported');


### PR DESCRIPTION
xref: https://github.com/cafebazaar/flutter_poolakey/issues/21

**Description**

I have found an issue with `Poolakey.connect()` on some Android phones, which leads to an `IllegalStateException`. This forces applications to crash. To fix this, I used `channel.invokeMethod` instead of `result.success`. For example, in `FlutterPoolakeyPlugin.kt` I used the following code:

```
paymentConnection = payment.connect {
            connectionSucceed {
                channel.invokeMethod("connectSuccess", null)
            }
            connectionFailed {
                channel.invokeMethod("connectFailed", null)
            }
            disconnected {
                channel.invokeMethod("disconnected", null)
            }
        }
```

Then, in flutter_poolakey.dart, I changed the `connect` and callback functions to work with invokeMethod like this:

```
static Future<void> connect(String? inAppBillingKey,
      {VoidCallback? onConnectSuccess,
      VoidCallback? onConnectFailed,
      VoidCallback? onDisconnected}) async {
    _registerConnectCallBack(onConnectSuccess, onConnectFailed, onDisconnected);
    await _channel
        .invokeMethod('connect', {'in_app_billing_key': inAppBillingKey});
  }

  static void _registerConnectCallBack(VoidCallback? onConnectSuccess,
      VoidCallback? onConnectFailed, VoidCallback? onDisconnected) {
    if (onConnectSuccess == null &&
        onConnectFailed == null &&
        onDisconnected == null) {
      return;
    }
    _channel.setMethodCallHandler((call) {
      if (call.method == 'disconnected') {
        onDisconnected?.call();
        return Future.value(true);
      } else if (call.method == 'connectSuccess') {
        onConnectSuccess?.call();
        return Future.value(true);
      } else if (call.method == 'connectFailed') {
        onConnectFailed?.call();
        return Future.value(true);
      }
      throw StateError('method ${call.method} is not supported');
    });
  }
```

Finally I, updated example code to work with new changes.
