### PR TITLE
Update README to reflect correct dependency format for flutter_poolakey

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,16 @@ project's `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  flutter_poolakey: ^2.2.0-1.0.0-alpha01
+  flutter_poolakey:
+    git:
+      url: https://github.com/cafebazaar/flutter_poolakey.git
+      ref: 2.2.0-1.0.0-alpha01
 ```
 
 Then run the below command to retrieve it:
 
 ```shell
-flutter packages get
+flutter pub get
 ```
 
 And then Go to the allprojects section of your project gradle file and add the JitPack repository to the repositories block:


### PR DESCRIPTION


**Summary of Change:**

The dependency declaration in the README.md was changed from:

```yaml
dependencies:
  flutter_poolakey: ^2.2.0-1.0.0-alpha01
```

to:

```yaml
dependencies:
  flutter_poolakey:
    git:
      url: https://github.com/cafebazaar/flutter_poolakey.git
      ref: 2.2.0-1.0.0-alpha01
```

**Reason:**

The version `2.2.0-1.0.0-alpha01` is not available on pub.dev, so users need to fetch it directly from the GitHub repository. This update helps developers add the correct dependency and avoid confusion or errors when running `flutter pub get`.